### PR TITLE
enable the operation on linux/docker env with Unity Editor

### DIFF
--- a/utils/config/default_env.bash
+++ b/utils/config/default_env.bash
@@ -36,8 +36,10 @@ then
 	then
 		export ETHRER_ID=eth0
 		export IFCONFIG_IPADDR=`ifconfig | grep -A 1 ${ETHRER_ID} | grep inet | awk '{print $2}'`
-		export RESOLVE_IPADDR=`cat /etc/resolv.conf | grep nameserver | awk '{print $2}'`
+  else
+		export IFCONFIG_IPADDR=127.0.0.1
 	fi
+	export RESOLVE_IPADDR=`cat /etc/resolv.conf | grep nameserver | awk '{print $2}'`
 else
 	export IFCONFIG_IPADDR=127.0.0.1
 	export RESOLVE_IPADDR=127.0.0.1

--- a/utils/config/env.bash
+++ b/utils/config/env.bash
@@ -2,7 +2,12 @@
 
 ####### Hakoniwa config ##########################
 #available values: wsl1 or wsl2 or linux or mac
-export OS_TYPE=wsl2
+if [[ "$(uname -r)" == *microsoft* ]];
+then
+	export OS_TYPE=wsl2
+else
+	export OS_TYPE=linux
+fi
 
 #available values: native or docker
 export RUNTIME_TYPE=docker


### PR DESCRIPTION
LinuxのDocker利用環境，アプリではなくUnity Editor上での操作，で動作可能なように修正しました．device_config.txt の `IFCONFIG_IPADDR` のとり方を変えています．ros2sim でのヘテロシミュレーションでは動作確認済みです．
WSL2環境が手元から無くなったので試せていません．そちらに悪影響が無いかをチェックしてもらえますか？