### PR TITLE
follow the latest instruction to install docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ $ service docker status
  * Docker is running   # or " * Docker is not running "
 ```
 
-Since the Docker Engine installation procedure is a bit complicated, we summarized it in [`docker/install-docker.bash`](/docker/install-docker.bash) in this repository (see [Install Docker Engine on Ubuntu | Docker Documentation](https://docs.docker.com/engine/install/ubuntu/)").  
-Execute as follows.
+Since the Docker Engine installation procedure is a bit complicated, we summarized it in [`docker/install-docker.bash`](/docker/install-docker.bash) in this repository by referring the official manual. If you have any trouble to execute this script, please follow the official manual to install Docker.  
+[Install Docker Engine on Ubuntu | Docker Documentation](https://docs.docker.com/engine/install/ubuntu/)
+
+Execute as follows to install Docker with our script.
 
 ```
 bash docker/install-docker.bash

--- a/README_jp.md
+++ b/README_jp.md
@@ -42,8 +42,10 @@ $ service docker status
  * Docker is running   # または " * Docker is not running "
 ```
 
-Docker Engineのインストールはやや手数が多いため，本リポジトリの [`docker/install-docker.bash`](/docker/install-docker.bash) にまとめてあります（「[Install Docker Engine on Ubuntu | Docker Documentation](https://docs.docker.com/engine/install/ubuntu/)」を参考に作成しました）．  
-下記のように実行してください．
+Docker Engineのインストールはやや手数が多いため，下記の公式マニュアルにある実行コマンドを本リポジトリの [`docker/install-docker.bash`](/docker/install-docker.bash) にまとめています．本スクリプトの実行時に問題がありましたら，公式マニュアルの手順に従ってインストールを進めてください．  
+[Install Docker Engine on Ubuntu | Docker Documentation](https://docs.docker.com/engine/install/ubuntu/)
+
+スクリプトを用いたDockerのインストールには，下記のように実行してください．
 
 ```
 bash docker/install-docker.bash

--- a/docker/install-docker.bash
+++ b/docker/install-docker.bash
@@ -19,21 +19,21 @@ fi
 # Set up the repository
 sudo apt-get update
 sudo apt-get install \
-    apt-transport-https \
     ca-certificates \
     curl \
     gnupg \
     lsb-release
 
 # Add Docker’s official GPG key:
-sudo rm -f /usr/share/keyrings/docker-archive-keyring.gpg
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+sudo rm -f /etc/apt/keyrings/docker.gpg
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 
 # Use the following command to set up the stable repository. 
 echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 # Install Docker Engine
 sudo apt-get update
-sudo apt-get install docker-ce docker-ce-cli containerd.io
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin


### PR DESCRIPTION
Docker公式ページのインストール手順が更新されていたので，それに追従しています．
https://docs.docker.com/engine/install/ubuntu/

手元の環境（Ubuntu20/x86のネイティブなlaptop）では，docker環境をサラにしてから旧版の `bash docker/install-docker.bash` したらうまくいかない -> またサラにして新版のをやったらうまくいく，ということは確認しています．ただこの変更でなんで良くなるのか（元々がダメなのか）というのは，たいした変更ではないはずなので実は割りと納得いっていないです．
あと念のためですが旧版のGPG鍵である `/usr/share/keyrings/docker-archive-keyring.gpg` は削除してしまったほうがいいかもしれません．